### PR TITLE
docs(dxCreateTexture): fix texture type argument name

### DIFF
--- a/functions/Drawing/dxCreateTexture.yaml
+++ b/functions/Drawing/dxCreateTexture.yaml
@@ -51,7 +51,7 @@ client:
           description: A [[string]] representing the desired texture edge handling.
           default: '"wrap"'
           templateList: texture-edges
-        - name: textureFormat
+        - name: textureType
           type: string
           description: A [[string]] representing the desired texture type.
           default: '"2d"'


### PR DESCRIPTION
## Summary

Correct the fifth optional parameter in the width/height overload of `dxCreateTexture` from `textureFormat` to `textureType`.

Before:

```lua
dxCreateTexture(width, height, textureFormat, textureEdge, textureFormat, depth)
```

After:

```lua
dxCreateTexture(width, height, textureFormat, textureEdge, textureType, depth)
```

## Reason

The previous parameter name duplicated `textureFormat`, while its description, default value (`"2d"`), `texture-types` template list, and changelog identify it as `textureType`.

The current MTA implementation also defines and reads this argument as `textureType`:

- [MTA source: `CLuaDrawingDefs::DxCreateTexture`](https://github.com/multitheftauto/mtasa-blue/blob/9f744604ea3e8a0bdc512add6263dfd0fc32e303/Client/mods/deathmatch/logic/luadefs/CLuaDrawingDefs.cpp#L980-L1028)
- [Official `dxCreateTexture` documentation](https://wiki.multitheftauto.com/wiki/DxCreateTexture)